### PR TITLE
allow multiline input for extra-images input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ const main = async () => {
   const extraImages = core.getInput('extra-images', { trimWhitespace: true, required: true });
   const shouldPush = core.getBooleanInput('push');
 
-  const imagesToCreate = extraImages.split(',');
+  const imagesToCreate = extraImages.split(',').map(i => i.trim());
   if (imagesToCreate.length === 0) {
     core.warning(
       `You will need some extra images to set, at the moment, you have none! Did you forget to use \`,\` as the seperator?`


### PR DESCRIPTION
```js
> '    foo, \n bar    '.trim().split(',').map(i => i.trim())
[ 'foo', 'bar' ]
> '    foo, \n bar    '.trim().split(',')
[ 'foo', ' \n bar' ]
```

this will allow both:

```yaml
extra-images: namespace/image:latest-amd64,namespace/image:latest-arm64,namespace/image:latest-armv7
```

as well as:

```yaml
extra-images: |
  namespace/image:latest-amd64,
  namespace/image:latest-arm64,
  namespace/image:latest-armv7
```

not switching to `getMultilineInput` so that its backward compatible and the delimiter is still a comma (`,`)