### PR TITLE
feat: output pushed images with digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ steps:
 > Type: String
 >
 > Required: True
-> Image name(s), optionally comma separated, that the final image manifest will be called.
+
+Image name(s), optionally comma separated, that the final image manifest will be called.
 
 #### Example
 

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,12 @@ runs:
 
 inputs:
     inputs:
-        description: A list of input Docker images (that were previously built) as the inputs for the merged manifests. Optionally, comma-seperate to create multiple final images with the same manifest.
+        description: A list of input Docker images (that were previously built) as the inputs for the merged manifests. Optionally, comma-separate to create multiple final images with the same manifest.
         required: false
         default: ''
 
     images:
-        description: Comma-seperated list of images that will be applied in the merged manifest from the `inputs`.
+        description: Comma-separated list of images that will be applied in the merged manifest from the `inputs`.
         required: false
         default: ''
 
@@ -63,3 +63,7 @@ inputs:
             This is useful if the action has created a manifest but had errored when creating (or pushing) a merged manifest.
         required: false
         default: 'false'
+
+outputs:
+    images:
+        description: Comma-separated list of pushed images.


### PR DESCRIPTION
Fixes #247. Adds an `images` output with comma-separated images including their digests.

The current `package.json` causes a runtime error, so I had to revert to 3b3592fbdc92448bf8c900410488aba3ec3c2f2a. CI also needed changes to run on a fork (#249).

Successful CI: https://github.com/pl4nty/docker-manifest-action/actions/runs/5500272730/jobs/10023077440
Successful test for my usecase (cosign): https://github.com/pl4nty/containers/actions/runs/5500373420/jobs/10023244496